### PR TITLE
Update use-package configurations

### DIFF
--- a/doc/modus-themes.info
+++ b/doc/modus-themes.info
@@ -559,7 +559,6 @@ package configurations in their setup.  We use this as an example:
        (load-theme 'modus-operandi t)
        :bind ("<f5>" . modus-themes-toggle)
        :custom
-       ;; Add all your customizations prior to loading the themes
        (modus-themes-italic-constructs t)
        (modus-themes-bold-constructs nil)
 
@@ -577,7 +576,6 @@ package configurations in their setup.  We use this as an example:
        (load-theme 'modus-operandi t)
        :bind ("<f5>" . modus-themes-toggle)
        :custom
-       ;; Add all your customizations prior to loading the themes
        (modus-themes-italic-constructs t)
        (modus-themes-bold-constructs nil)
 

--- a/doc/modus-themes.info
+++ b/doc/modus-themes.info
@@ -552,40 +552,38 @@ What follows is a variant of what we demonstrate in the previous section
 package configurations in their setup.  We use this as an example:
 
      ;;; For the built-in themes which cannot use `require'.
-     (use-package emacs
-       :config
-       (require-theme 'modus-themes) ; `require-theme' is ONLY for the built-in Modus themes
-
+     (use-package modus-themes
+       :ensure nil ; `:ensure nil' is ONLY for the built-in Modus themes
+       :init
+       ;; Load the theme of your choice
+       (load-theme 'modus-operandi t)
+       :bind ("<f5>" . modus-themes-toggle)
+       :custom
        ;; Add all your customizations prior to loading the themes
-       (setq modus-themes-italic-constructs t
-             modus-themes-bold-constructs nil)
+       (modus-themes-italic-constructs t)
+       (modus-themes-bold-constructs nil)
 
        ;; Maybe define some palette overrides, such as by using our presets
-       (setq modus-themes-common-palette-overrides
-             modus-themes-preset-overrides-intense)
-
-       ;; Load the theme of your choice.
-       (load-theme 'modus-operandi)
-       :bind ("<f5>" . modus-themes-toggle))
+       (modus-themes-common-palette-overrides)
+       (modus-themes-preset-overrides-intense))
 
 
 
      ;;; For packaged versions which must use `require'.
      (use-package modus-themes
        :ensure t
-       :demand t
-       :config
+       :init
+       ;; Load the theme of your choice
+       (load-theme 'modus-operandi t)
+       :bind ("<f5>" . modus-themes-toggle)
+       :custom
        ;; Add all your customizations prior to loading the themes
-       (setq modus-themes-italic-constructs t
-             modus-themes-bold-constructs nil)
+       (modus-themes-italic-constructs t)
+       (modus-themes-bold-constructs nil)
 
        ;; Maybe define some palette overrides, such as by using our presets
-       (setq modus-themes-common-palette-overrides
-             modus-themes-preset-overrides-intense)
-
-       ;; Load the theme of your choice.
-       (load-theme 'modus-operandi :no-confirm)
-       :bind ("<f5>" . modus-themes-toggle))
+       (modus-themes-common-palette-overrides)
+       (modus-themes-preset-overrides-intense))
 
    The same without ‘use-package’:
 

--- a/doc/modus-themes.org
+++ b/doc/modus-themes.org
@@ -384,7 +384,6 @@ package configurations in their setup.  We use this as an example:
     (load-theme 'modus-operandi t)
     :bind ("<f5>" . modus-themes-toggle)
     :custom
-    ;; Add all your customizations prior to loading the themes
     (modus-themes-italic-constructs t)
     (modus-themes-bold-constructs nil)
 
@@ -402,7 +401,6 @@ package configurations in their setup.  We use this as an example:
     (load-theme 'modus-operandi t)
     :bind ("<f5>" . modus-themes-toggle)
     :custom
-    ;; Add all your customizations prior to loading the themes
     (modus-themes-italic-constructs t)
     (modus-themes-bold-constructs nil)
 

--- a/doc/modus-themes.org
+++ b/doc/modus-themes.org
@@ -376,41 +376,39 @@ It is common for Emacs users to rely on ~use-package~ for declaring
 package configurations in their setup.  We use this as an example:
 
 #+begin_src emacs-lisp
-;;; For the built-in themes which cannot use `require'.
-(use-package emacs
-  :config
-  (require-theme 'modus-themes) ; `require-theme' is ONLY for the built-in Modus themes
+  ;;; For the built-in themes which cannot use `require'.
+  (use-package modus-themes
+    :ensure nil ; `:ensure nil' is ONLY for the built-in Modus themes
+    :init
+    ;; Load the theme of your choice
+    (load-theme 'modus-operandi t)
+    :bind ("<f5>" . modus-themes-toggle)
+    :custom
+    ;; Add all your customizations prior to loading the themes
+    (modus-themes-italic-constructs t)
+    (modus-themes-bold-constructs nil)
 
-  ;; Add all your customizations prior to loading the themes
-  (setq modus-themes-italic-constructs t
-        modus-themes-bold-constructs nil)
-
-  ;; Maybe define some palette overrides, such as by using our presets
-  (setq modus-themes-common-palette-overrides
-        modus-themes-preset-overrides-intense)
-
-  ;; Load the theme of your choice.
-  (load-theme 'modus-operandi)
-  :bind ("<f5>" . modus-themes-toggle))
-
+    ;; Maybe define some palette overrides, such as by using our presets
+    (modus-themes-common-palette-overrides)
+    (modus-themes-preset-overrides-intense))
 
 
-;;; For packaged versions which must use `require'.
-(use-package modus-themes
-  :ensure t
-  :demand t
-  :config
-  ;; Add all your customizations prior to loading the themes
-  (setq modus-themes-italic-constructs t
-        modus-themes-bold-constructs nil)
 
-  ;; Maybe define some palette overrides, such as by using our presets
-  (setq modus-themes-common-palette-overrides
-        modus-themes-preset-overrides-intense)
+  ;;; For packaged versions which must use `require'.
+  (use-package modus-themes
+    :ensure t
+    :init
+    ;; Load the theme of your choice
+    (load-theme 'modus-operandi t)
+    :bind ("<f5>" . modus-themes-toggle)
+    :custom
+    ;; Add all your customizations prior to loading the themes
+    (modus-themes-italic-constructs t)
+    (modus-themes-bold-constructs nil)
 
-  ;; Load the theme of your choice.
-  (load-theme 'modus-operandi :no-confirm)
-  :bind ("<f5>" . modus-themes-toggle))
+    ;; Maybe define some palette overrides, such as by using our presets
+    (modus-themes-common-palette-overrides)
+    (modus-themes-preset-overrides-intense))
 #+end_src
 
 The same without ~use-package~:


### PR DESCRIPTION
`:bind` defers the loading of the package (see https://github.com/jwiegley/use-package#modes-and-interpreters) preventing `load-theme` to load the theme (even if `load-theme` is before `:bind`). I updated the code to use `:init` instead.

`:ensure nil` tells Emacs to configure the built-in package and do not look for it in the online repositories.

Also, I use `:custom` instead of `:config` because `C-h v` categorizes all those variables in the "customization" category. 

![Alt text](https://i.ibb.co/FB3930y/customize.jpg)

As far as I know only those that do not have "Customize" listed should be added to `:config`. At least, that's what I do in all my configs.

Variables listed in the `:custom` don't require `setq`.

I tested the configurations.