### PR TITLE
Update use-package configurations

### DIFF
--- a/doc/modus-themes.info
+++ b/doc/modus-themes.info
@@ -552,40 +552,36 @@ What follows is a variant of what we demonstrate in the previous section
 package configurations in their setup.  We use this as an example:
 
      ;;; For the built-in themes which cannot use `require'.
-     (use-package emacs
-       :config
-       (require-theme 'modus-themes) ; `require-theme' is ONLY for the built-in Modus themes
-
-       ;; Add all your customizations prior to loading the themes
-       (setq modus-themes-italic-constructs t
-             modus-themes-bold-constructs nil)
+     (use-package modus-themes
+       :ensure nil ; `:ensure nil' is ONLY for the built-in Modus themes
+       :init
+       ;; Load the theme of your choice
+       (load-theme 'modus-operandi t)
+       :bind ("<f5>" . modus-themes-toggle)
+       :custom
+       (modus-themes-italic-constructs t)
+       (modus-themes-bold-constructs nil)
 
        ;; Maybe define some palette overrides, such as by using our presets
-       (setq modus-themes-common-palette-overrides
-             modus-themes-preset-overrides-intense)
-
-       ;; Load the theme of your choice.
-       (load-theme 'modus-operandi)
-       :bind ("<f5>" . modus-themes-toggle))
+       (modus-themes-common-palette-overrides)
+       (modus-themes-preset-overrides-intense))
 
 
 
      ;;; For packaged versions which must use `require'.
      (use-package modus-themes
        :ensure t
-       :demand t
-       :config
-       ;; Add all your customizations prior to loading the themes
-       (setq modus-themes-italic-constructs t
-             modus-themes-bold-constructs nil)
+       :init
+       ;; Load the theme of your choice
+       (load-theme 'modus-operandi t)
+       :bind ("<f5>" . modus-themes-toggle)
+       :custom
+       (modus-themes-italic-constructs t)
+       (modus-themes-bold-constructs nil)
 
        ;; Maybe define some palette overrides, such as by using our presets
-       (setq modus-themes-common-palette-overrides
-             modus-themes-preset-overrides-intense)
-
-       ;; Load the theme of your choice.
-       (load-theme 'modus-operandi :no-confirm)
-       :bind ("<f5>" . modus-themes-toggle))
+       (modus-themes-common-palette-overrides)
+       (modus-themes-preset-overrides-intense))
 
    The same without ‘use-package’:
 

--- a/doc/modus-themes.org
+++ b/doc/modus-themes.org
@@ -376,41 +376,37 @@ It is common for Emacs users to rely on ~use-package~ for declaring
 package configurations in their setup.  We use this as an example:
 
 #+begin_src emacs-lisp
-;;; For the built-in themes which cannot use `require'.
-(use-package emacs
-  :config
-  (require-theme 'modus-themes) ; `require-theme' is ONLY for the built-in Modus themes
+  ;;; For the built-in themes which cannot use `require'.
+  (use-package modus-themes
+    :ensure nil ; `:ensure nil' is ONLY for the built-in Modus themes
+    :init
+    ;; Load the theme of your choice
+    (load-theme 'modus-operandi t)
+    :bind ("<f5>" . modus-themes-toggle)
+    :custom
+    (modus-themes-italic-constructs t)
+    (modus-themes-bold-constructs nil)
 
-  ;; Add all your customizations prior to loading the themes
-  (setq modus-themes-italic-constructs t
-        modus-themes-bold-constructs nil)
-
-  ;; Maybe define some palette overrides, such as by using our presets
-  (setq modus-themes-common-palette-overrides
-        modus-themes-preset-overrides-intense)
-
-  ;; Load the theme of your choice.
-  (load-theme 'modus-operandi)
-  :bind ("<f5>" . modus-themes-toggle))
+    ;; Maybe define some palette overrides, such as by using our presets
+    (modus-themes-common-palette-overrides)
+    (modus-themes-preset-overrides-intense))
 
 
 
-;;; For packaged versions which must use `require'.
-(use-package modus-themes
-  :ensure t
-  :demand t
-  :config
-  ;; Add all your customizations prior to loading the themes
-  (setq modus-themes-italic-constructs t
-        modus-themes-bold-constructs nil)
+  ;;; For packaged versions which must use `require'.
+  (use-package modus-themes
+    :ensure t
+    :init
+    ;; Load the theme of your choice
+    (load-theme 'modus-operandi t)
+    :bind ("<f5>" . modus-themes-toggle)
+    :custom
+    (modus-themes-italic-constructs t)
+    (modus-themes-bold-constructs nil)
 
-  ;; Maybe define some palette overrides, such as by using our presets
-  (setq modus-themes-common-palette-overrides
-        modus-themes-preset-overrides-intense)
-
-  ;; Load the theme of your choice.
-  (load-theme 'modus-operandi :no-confirm)
-  :bind ("<f5>" . modus-themes-toggle))
+    ;; Maybe define some palette overrides, such as by using our presets
+    (modus-themes-common-palette-overrides)
+    (modus-themes-preset-overrides-intense))
 #+end_src
 
 The same without ~use-package~:


### PR DESCRIPTION
`:bind` defers the loading of the package (see https://github.com/jwiegley/use-package#modes-and-interpreters) preventing `load-theme` to load the theme (even if `load-theme` is listed before `:bind`). The solution is to use `:init`.

`:ensure nil` tells Emacs to configure the built-in package and do not look for it in the online repositories.

Also, I use `:custom` instead of `:config` because `C-h v` categorizes all those variables in the "customization" category.
Variables listed in the `:custom` don't require `setq`.

I tested the configurations before commiting.