### PR TITLE
Change smerge-markers to inherit from diff-header instead of heading

### DIFF
--- a/modus-themes.el
+++ b/modus-themes.el
@@ -3439,7 +3439,7 @@ FG and BG are the main colors."
 ;;;;; smerge
     `(smerge-base ((,c :inherit diff-changed)))
     `(smerge-lower ((,c :inherit diff-added)))
-    `(smerge-markers ((,c :inherit diff-heading)))
+    `(smerge-markers ((,c :inherit diff-header)))
     `(smerge-refined-added ((,c :inherit diff-refine-added)))
     `(smerge-refined-changed (()))
     `(smerge-refined-removed ((,c :inherit diff-refine-removed)))


### PR DESCRIPTION
The face diff-heading doesn't pre-exist, and there is no longer a custom modus theme diff-heading. There is, however, a diff-header used in the "diff" faces that is probably intended here.