### PR TITLE
Add support for `xterm-color` and (parts of) `rustic-mode`

### DIFF
--- a/modus-themes.el
+++ b/modus-themes.el
@@ -4174,7 +4174,26 @@ FG and BG are the main colors."
             ("yaml" modus-themes-nuanced-cyan)
             ("conf" modus-themes-nuanced-cyan)
             ("docker" modus-themes-nuanced-cyan)))
-      `(org-src-block-faces '())))
+      `(org-src-block-faces '()))
+;;;; xterm-color
+    `(xterm-color-names
+      [,fg-term-black
+       ,fg-term-red
+       ,fg-term-green
+       ,fg-term-yellow
+       ,fg-term-blue
+       ,fg-term-magenta
+       ,fg-term-cyan
+       ,fg-term-white])
+    `(xterm-color-names-bright
+      [,fg-term-black-bright
+       ,fg-term-red-bright
+       ,fg-term-green-bright
+       ,fg-term-yellow-bright
+       ,fg-term-blue-bright
+       ,fg-term-magenta-bright
+       ,fg-term-cyan-bright
+       ,fg-term-white-bright]))
   "Custom variables for `modus-themes-theme'.")
 
 ;;; Theme macros

--- a/modus-themes.el
+++ b/modus-themes.el
@@ -4152,6 +4152,16 @@ FG and BG are the main colors."
         modus-themes-fg-yellow-intense
         modus-themes-fg-magenta-intense
         modus-themes-fg-cyan-intense))
+;;;; rustic-ansi-faces
+    `(rustic-ansi-faces
+      [,fg-term-black
+       ,fg-term-red
+       ,fg-term-green
+       ,fg-term-yellow
+       ,fg-term-blue
+       ,fg-term-magenta
+       ,fg-term-cyan
+       ,fg-term-white])
 ;;;; org-src-block-faces
     (if (or (eq modus-themes-org-blocks 'tinted-background)
             (eq modus-themes-org-blocks 'rainbow))


### PR DESCRIPTION
Hi Prot,

this is a tiny PR that adds support for `xterm-color.el`—which is a library that works much like `ansi-color.el`—as well as the compilation part of `rustic-mode` (because they inconveniently overwrite the respective `xterm-color` settings with their own). These changes are essentially analogous to what's already been done for `ansi-color-names-vector`.

Without this override, the compilation buffer may sometimes look like this:

![2024-02-25-084128_301x53_scrot](https://github.com/protesilaos/modus-themes/assets/50166980/68a3627d-9d19-4837-a34c-9fd642b9e592)

I'm sure you'll agree that this is quite unreadable :)

### Commit Summary

#### Add support for rustic-ansi-faces

Most of rustic-modes faces are deprecated in favour of this unifying approach, hence only this one face is added. Unlike the name suggests, this does not use ansi-color.el, but rather xterm-color.el; this has no effect in terms of the color specification, though.

#### Add xterm-color support

This is a GNU ELPA package that essentially does what ansi-color.el also does. The reason for supporting it is that other third-party packages may depend on xterm-color, and if we just leave it to its own devices it may produce nearly unreadable output.