### PR TITLE
Remove redundant theme name argument from modus-themes-declare call

### DIFF
--- a/modus-themes.el
+++ b/modus-themes.el
@@ -7345,7 +7345,7 @@ Consult the manual for details on how to build a theme on top of the
        ,@(unless theme-exists-p
            (list
             `(modus-themes-declare
-              ',name ',family ',(intern (format "%s-theme" name))
+              ',name ',family
               ,description ',background-mode
               ',core-palette ',user-palette ',overrides-palette)))
        ,@(unless (eq family 'modus-themes)


### PR DESCRIPTION
The function doesn't accept this parameter and constructs it internally.