### PR TITLE
Make markdown-code-face consistent with org-block

### DIFF
--- a/modus-themes.el
+++ b/modus-themes.el
@@ -5959,7 +5959,7 @@ FG and BG are the main colors."
 ;;;;; markdown-mode
     `(markdown-blockquote-face ((,c :inherit font-lock-doc-face)))
     `(markdown-bold-face ((,c :inherit bold)))
-    `(markdown-code-face ((,c :inherit modus-themes-fixed-pitch :background ,bg-dim :extend t)))
+    `(markdown-code-face ((,c :inherit modus-themes-fixed-pitch :background ,bg-prose-block-contents :extend t)))
     `(markdown-gfm-checkbox-face ((,c :foreground ,warning)))
     `(markdown-header-face (( )))
     `(markdown-header-face-1 ((,c :inherit modus-themes-heading-1)))


### PR DESCRIPTION
According to section 7.3.15 of info manual, Org and Markdown code blocks should be consistent. It's currently true with provided themes only because `bg-prose-block-contents` is mapped to `bg-dim`. If these two faces are overridden with different values, consistency is lost.