### PR TITLE
Fix powerline theme definitions for inactive states

### DIFF
--- a/modus-themes.el
+++ b/modus-themes.el
@@ -6441,21 +6441,21 @@ FG and BG are the main colors."
         :box ,border-mode-line-active)
        (t :underline ,border-mode-line-active)))
     `(powerline-active2
-      (((default :inherit modus-themes-ui-variable-pitch
+      ((default :inherit modus-themes-ui-variable-pitch
                 :background ,bg-mode-line-inactive
                 :foreground ,fg-mode-line-inactive)
        (((supports :box t))
         :box ,border-mode-line-inactive)
-       (t :underline ,border-mode-line-inactive))))
+       (t :underline ,border-mode-line-inactive)))
     `(powerline-inactive0 ((,c :background ,bg-active :foreground ,fg-dim)))
     `(powerline-inactive1 ((,c :background ,bg-main :foreground ,fg-dim)))
     `(powerline-inactive2
-      (((default :inherit modus-themes-ui-variable-pitch
+      ((default :inherit modus-themes-ui-variable-pitch
                 :background ,bg-mode-line-inactive
                 :foreground ,fg-mode-line-inactive)
        (((supports :box t))
         :box ,border-mode-line-inactive)
-       (t :underline ,border-mode-line-inactive))))
+       (t :underline ,border-mode-line-inactive)))
 ;;;;; powerline-evil
     `(powerline-evil-base-face ((,c :background ,fg-main :foreground ,bg-main)))
     `(powerline-evil-emacs-face ((,c :inherit modus-themes-bold :background ,bg-main)))


### PR DESCRIPTION
This was broken by 08820b2

```
Debugger entered--Lisp error: (wrong-type-argument listp default)
  face-spec-set-match-display((default :inherit modus-themes-ui-variable-pitch :background "#292d48" :foreground "#969696") #<frame  0x13e8b9a28>)
  face-spec-choose((((default :inherit modus-themes-ui-variable-pitch :background "#292d48" :foreground "#969696") (((supports :box t)) :box "#606270") (t :underline "#606270"))) #<frame  0x13e8b9a28> 0)
  face-spec-recalc(powerline-inactive2 #<frame  0x13e8b9a28>)
  custom-theme-recalc-face(powerline-inactive2)
  #<subr enable-theme>(modus-vivendi-tinted)
  apply(#<subr enable-theme> modus-vivendi-tinted)
  enable-theme(modus-vivendi-tinted)
  #<subr load-theme>(modus-vivendi-tinted nil nil)
  apply(#<subr load-theme> (modus-vivendi-tinted nil nil))
  load-theme(modus-vivendi-tinted nil nil)
  funcall-interactively(load-theme modus-vivendi-tinted nil nil)
  command-execute(load-theme record)
  #<subr execute-extended-command>(nil "load-theme" nil)
  ad-Advice-execute-extended-command(#<subr execute-extended-command> nil "load-theme" nil)
  apply(ad-Advice-execute-extended-command #<subr execute-extended-command> (nil "load-theme" nil))
  execute-extended-command(nil "load-theme" nil)
  funcall-interactively(execute-extended-command nil "load-theme" nil)
  command-execute(execute-extended-command)
```