### PR TITLE
 Fix modus-themes-toggle and modus-themes--disable-themes

### DIFF
--- a/modus-themes.el
+++ b/modus-themes.el
@@ -4083,8 +4083,9 @@ Disable other themes per `modus-themes-disable-other-themes'."
   (interactive)
   (if-let* ((themes (modus-themes-known-p modus-themes-to-toggle))
             (one (car themes))
-            (two (cadr themes)))
-      (modus-themes-load-theme (if (eq (car custom-enabled-themes) one) two one))
+            (two (cadr themes))
+            (current (modus-themes-get-current-theme)))
+      (modus-themes-load-theme (if (eq current one) two one))
     (modus-themes-load-theme (modus-themes-select-prompt "No valid theme to toggle; select other"))))
 
 ;;;;; Rotate through a list of themes


### PR DESCRIPTION
In my attempt to use `modus-themes-toggle` I've found two problems this PR try to solve:

- `modus-themes-toggle` has the same bug you fixed in 117875cb12c92f93f94b3ffff61a5446e82bd29d
- when `modus-themes-disable-other-themes` is set to `nil`,  `modus-themes--disable-themes` doesn't disable other modus themes as expected.

I've added `modus-themes--modus-theme-p`  predicate and rewrite `modus-themes--disable-themes` and `modus-themes-get-current-theme` to use it.