### PR TITLE
Set widget-field underline face to border color

### DIFF
--- a/modus-themes.el
+++ b/modus-themes.el
@@ -7253,9 +7253,9 @@ If COLOR is unspecified, then return :box unspecified."
     `(widget-button ((,c :inherit modus-themes-bold :foreground ,fg-link)))
     `(widget-button-pressed ((,c :inherit modus-themes-bold :foreground ,fg-link-visited)))
     `(widget-documentation ((,c :inherit modus-themes-slant :foreground ,docstring)))
-    `(widget-field ((,c :background ,bg-button-inactive :foreground ,fg-button-active :extend nil :underline (:position t))))
+    `(widget-field ((,c :background ,bg-button-inactive :foreground ,fg-button-active :extend nil :underline (:position t :color ,border))))
     `(widget-inactive ((,c :background ,bg-button-inactive :foreground ,fg-button-inactive)))
-    `(widget-single-line-field ((,c :background ,bg-button-inactive :foreground ,fg-button-active :extend nil :underline (:position t))))
+    `(widget-single-line-field ((,c :background ,bg-button-inactive :foreground ,fg-button-active :extend nil :underline (:position t :color ,border))))
 ;;;;; writegood-mode
     `(writegood-duplicates-face ((,c :underline (:style wave :color ,underline-err))))
     `(writegood-passive-voice-face ((,c :underline (:style wave :color ,underline-warning))))


### PR DESCRIPTION
The widget-field underline inherits the foreground color by default. This change ensures it uses the border face for better visual consistency.

Fixes: https://github.com/protesilaos/modus-themes/issues/192