### PR TITLE
Fix regression in mc/cursor-mc/cursor-bar-face

### DIFF
--- a/modus-themes.el
+++ b/modus-themes.el
@@ -6308,7 +6308,7 @@ If COLOR is unspecified, then return :box unspecified."
     `(mu4e-view-body-face (( )))
     `(mu4e-warning-face ((,c :foreground ,warning)))
 ;;;;; multiple-cursors
-    `(mc/cursor-bar-face ((,c :height 1 :foreground ,fg-main :background ,bg-main)))
+    `(mc/cursor-bar-face ((,c :height 1 :background ,cursor)))
     `(mc/cursor-face ((,c :inverse-video t)))
     `(mc/region-face ((,c :background ,bg-region :foreground ,fg-region)))
 ;;;;; nerd-icons


### PR DESCRIPTION
This fixes a regression made in #47 for the multi-cursor bar face, which caused the cursor bars to not display (At least in GUI sessions, for TUI probably it won't work, but it seems this is more multiple-cursors problem rather than modus-themes).